### PR TITLE
Ensure function prints are scoped within parentheses

### DIFF
--- a/biomechanics/curve.py
+++ b/biomechanics/curve.py
@@ -29,7 +29,7 @@ class CharacteristicCurveFunction(Function):
         return self.doit(deep=False, evaluate=False)._eval_evalf(prec)
 
     def _print_code(self, printer):
-        return printer.doprint(self.doit(deep=False, evaluate=False))
+        return f'({printer.doprint(self.doit(deep=False, evaluate=False))})'
 
     _ccode = _print_code
     _cupycode = _print_code


### PR DESCRIPTION
Found a bug related to printing of musculotendon curves with more complex expressions. Here's a simple example to explain what was going on:

- Consider `f1(a, b)` is a SymPy `Function` with two variables `a` and `b` where `f1` simply corresponds to `a + b`
- Consider `f2(c, d)` is a SymPy `Function` with two variables `c` and `d` where `f2` simply corresponds to `c - d`
- Using a code printer on `f1` prints `a + b`
- Using a code printer on `f2` prints `c - d`
- Create a SymPy expression like `expr = f1(a, b)*f2(c, d)`
- Using a code printer on `expr` prints `a + b*c - d`; it's not scoping the functions within brackets so gives the wrong numerical result.

Solution: ensure that when these subclasses of `Function` print (musculotendon curves in our case) that the resulting expressions are enclosed within brackets. Currently implemented just by wrapping the printed string in brackets, but there might be a safer way to do this using one of SymPy's methods on the `Printer` classes.